### PR TITLE
 Refactor error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/webrtc-rs/srtp"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { package = "webrtc-rs-util", version = "0.1.1" }
+util = { package = "webrtc-rs-util", version = "0.1.5" }
 rtp = { package = "webrtc-rs-rtp", version = "0.1.0" }
 rtcp = { package = "webrtc-rs-rtcp", version = "0.1.0" }
 byteorder = "1.3.2"
-hmac = "0.10.1"
+hmac = { version = "0.10.1", features = ["std"] }
 sha-1 = "0.9.1"
 ctr = "0.6.0"
 aes = "0.6.0"
@@ -24,8 +24,9 @@ subtle = "2.1.1"
 tokio = { version = "1.0", features = ["full"] }
 async-trait = "0.1"
 log = "0.4"
-aead = "^0.3"
+aead = { version = "^0.3", features = ["std"] }
 aes-gcm = "^0.8"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/cipher/cipher_aead_aes_gcm.rs
+++ b/src/cipher/cipher_aead_aes_gcm.rs
@@ -4,10 +4,9 @@ use aes_gcm::{
 };
 use byteorder::{BigEndian, ByteOrder};
 use rtp::header;
-use util::Error;
 
 use super::Cipher;
-use crate::{context, key_derivation};
+use crate::{context, error::Error, key_derivation};
 
 pub(crate) const CIPHER_AEAD_AES_GCM_AUTH_TAG_LEN: usize = 16;
 const RTCP_ENCRYPTION_FLAG: u8 = 0x80;

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -5,7 +5,7 @@ mod test;
 pub(crate) use cipher_aead_aes_gcm::CipherAeadAesGcm;
 pub(crate) use cipher_aes_cm_hmac_sha1::CipherAesCmHmacSha1;
 
-use util::Error;
+use crate::error::Error;
 
 /// Cipher represents a implementation of one
 /// of the SRTP Specific ciphers.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
-use util::Error;
-
 use super::option::*;
 use super::protection_profile::*;
+use crate::error::Error;
 
 const LABEL_EXTRACTOR_DTLS_SRTP: &str = "EXTRACTOR-dtls_srtp";
 

--- a/src/context/context_test.rs
+++ b/src/context/context_test.rs
@@ -1,10 +1,9 @@
 #[cfg(test)]
 mod context_test {
     use crate::{
-        context, context::Context, key_derivation::*, protection_profile::ProtectionProfile,
+        context, context::Context, error::Error, key_derivation::*,
+        protection_profile::ProtectionProfile,
     };
-
-    use util::Error;
 
     const CIPHER_CONTEXT_ALGO: ProtectionProfile = ProtectionProfile::AES128CMHMACSHA1_80;
     const DEFAULT_SSRC: u32 = 0;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
 use util::replay_detector::*;
-use util::Error;
 
 use super::protection_profile::*;
-use crate::{cipher, option};
+use crate::{cipher, error::Error, option};
 
 mod context_test;
 mod srtcp_test;
@@ -129,17 +128,9 @@ impl Context {
         let salt_len = profile.salt_len()?;
 
         if master_key.len() != key_len {
-            return Err(Error::new(format!(
-                "SRTP Master Key must be len {}, got {}",
-                key_len,
-                master_key.len()
-            )));
+            return Err(Error::SrtpMasterKeyLength(key_len, master_key.len()));
         } else if master_salt.len() != salt_len {
-            return Err(Error::new(format!(
-                "SRTP Salt must be len {}, got {}",
-                salt_len,
-                master_salt.len()
-            )));
+            return Err(Error::SrtpSaltLength(salt_len, master_salt.len()));
         }
 
         let cipher: Box<dyn cipher::Cipher + Send> = match profile {

--- a/src/context/srtcp.rs
+++ b/src/context/srtcp.rs
@@ -23,17 +23,11 @@ impl Context {
             if let Some(state) = self.get_srtcp_ssrc_state(ssrc) {
                 if let Some(replay_detector) = &mut state.replay_detector {
                     if !replay_detector.check(index as u64) {
-                        return Err(Error::new(format!(
-                            "srtcp ssrc={} index={}: duplicated",
-                            ssrc, index
-                        )));
+                        return Err(Error::SrtcpSsrcDuplicated(ssrc, index));
                     }
                 }
             } else {
-                return Err(Error::new(format!(
-                    "ssrc {} not exist in srtcp_ssrc_state",
-                    ssrc
-                )));
+                return Err(Error::SsrcMissingFromSrtcp(ssrc));
             }
         }
 
@@ -72,13 +66,10 @@ impl Context {
                 }
                 index = state.srtcp_index;
             } else {
-                return Err(Error::new(format!(
-                    "ssrc {} not exist in srtcp_ssrc_state",
-                    ssrc
-                )));
+                return Err(Error::SsrcMissingFromSrtcp(ssrc));
             }
         }
 
-        self.cipher.encrypt_rtcp(decrypted, index, ssrc)
+        Ok(self.cipher.encrypt_rtcp(decrypted, index, ssrc)?)
     }
 }

--- a/src/context/srtcp_test.rs
+++ b/src/context/srtcp_test.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod test {
-    use crate::{context, context::Context, option, protection_profile::ProtectionProfile};
+    use crate::{
+        context, context::Context, error::Error, option, protection_profile::ProtectionProfile,
+    };
 
     use byteorder::{BigEndian, ReadBytesExt};
     use lazy_static::lazy_static;
     use std::io::Cursor;
-    use util::Error;
 
     pub struct RTCPTestCase {
         ssrc: u32,

--- a/src/context/srtp.rs
+++ b/src/context/srtp.rs
@@ -13,19 +13,16 @@ impl Context {
             if let Some(state) = self.get_srtp_ssrc_state(header.ssrc) {
                 if let Some(replay_detector) = &mut state.replay_detector {
                     if !replay_detector.check(header.sequence_number as u64) {
-                        return Err(Error::new(format!(
-                            "srtp ssrc={} index={}: duplicated",
-                            header.ssrc, header.sequence_number
-                        )));
+                        return Err(Error::SrtpSsrcDuplicated(
+                            header.ssrc,
+                            header.sequence_number,
+                        ));
                     }
                 }
 
                 roc = state.next_rollover_count(header.sequence_number);
             } else {
-                return Err(Error::new(format!(
-                    "ssrc {} not exist in srtp_ssrc_state",
-                    header.ssrc
-                )));
+                return Err(Error::SsrcMissingFromSrtp(header.ssrc));
             }
         }
 
@@ -59,10 +56,7 @@ impl Context {
             if let Some(state) = self.get_srtp_ssrc_state(header.ssrc) {
                 roc = state.next_rollover_count(header.sequence_number);
             } else {
-                return Err(Error::new(format!(
-                    "ssrc {} not exist in srtp_ssrc_state",
-                    header.ssrc
-                )));
+                return Err(Error::SsrcMissingFromSrtp(header.ssrc));
             }
         }
 

--- a/src/context/srtp_test.rs
+++ b/src/context/srtp_test.rs
@@ -3,9 +3,8 @@
 //TODO: BenchmarkDecryptRTP
 #[cfg(test)]
 mod srtp_test {
-    use crate::{context::Context, protection_profile::ProtectionProfile};
+    use crate::{context::Context, error::Error, protection_profile::ProtectionProfile};
     use std::io::BufWriter;
-    use util::Error;
 
     use lazy_static::lazy_static;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,57 @@
+use thiserror::Error;
+
+use crate::stream::Stream;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("index_over_kdr > 0 is not supported yet")]
+    UnsupportedIndexOverKdr,
+    #[error("SRTP Master Key must be len {0}, got {1}")]
+    SrtpMasterKeyLength(usize, usize),
+    #[error("SRTP Salt must be len {0}, got {1}")]
+    SrtpSaltLength(usize, usize),
+    #[error("SyntaxError: {0}")]
+    ExtMapParse(String),
+    #[error("ssrc {0} not exist in srtp_ssrc_state")]
+    SsrcMissingFromSrtp(u32),
+    #[error("srtp ssrc={0} index={1}: duplicated")]
+    SrtpSsrcDuplicated(u32, u16),
+    #[error("srtcp ssrc={0} index={1}: duplicated")]
+    SrtcpSsrcDuplicated(u32, usize),
+    #[error("ssrc {0} not exist in srtcp_ssrc_state")]
+    SsrcMissingFromSrtcp(u32),
+    #[error("Stream with ssrc {0} exists")]
+    StreamWithSsrcExists(u32),
+    #[error("Session RTP/RTCP type must be same as input buffer")]
+    SessionRtpRtcpTypeMismatch,
+    #[error("Session EOF")]
+    SessionEof,
+    #[error("too short SRTP packet: only {0} bytes, expected > {1} bytes")]
+    SrtpTooSmall(usize, usize),
+    #[error("too short SRTCP packet: only {0} bytes, expected > {1} bytes")]
+    SrtcpTooSmall(usize, usize),
+    #[error("failed to verify rtp auth tag")]
+    RtpFailedToVerifyAuthTag,
+    #[error("failed to verify rtcp auth tag")]
+    RtcpFailedToVerifyAuthTag,
+    #[error("SessionSRTP has been closed")]
+    SessionSrtpAlreadyClosed,
+    #[error("this stream is not a RTPStream")]
+    InvalidRtpStream,
+    #[error("this stream is not a RTCPStream")]
+    InvalidRtcpStream,
+    #[error("WebRtcUtilError: {0}")]
+    Util(#[from] util::Error),
+    #[error("IoError: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("AesGcm: {0}")]
+    AesGcm(#[from] aes_gcm::Error),
+    #[error("InvalidKeyLength: {0}")]
+    InvalidKeyLength(#[from] hmac::crypto_mac::InvalidKeyLength),
+    #[error("SendError: {0}")]
+    SendUnit(#[from] tokio::sync::mpsc::error::SendError<()>),
+    #[error("SendError: {0}")]
+    SendU32(#[from] tokio::sync::mpsc::error::SendError<u32>),
+    #[error("SendError: {0}")]
+    SendStream(#[from] tokio::sync::mpsc::error::SendError<Stream>),
+}

--- a/src/key_derivation/key_derivation_test.rs
+++ b/src/key_derivation/key_derivation_test.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::{context, key_derivation, protection_profile::ProtectionProfile};
-
-    use util::Error;
+    use crate::{context, error::Error, key_derivation, protection_profile::ProtectionProfile};
 
     #[test]
     fn test_valid_session_keys() -> Result<(), Error> {

--- a/src/key_derivation/mod.rs
+++ b/src/key_derivation/mod.rs
@@ -8,7 +8,7 @@ use std::io::BufWriter;
 
 use byteorder::{BigEndian, WriteBytesExt};
 
-use util::Error;
+use crate::error::Error;
 
 pub(crate) fn aes_cm_key_derivation(
     label: u8,
@@ -19,9 +19,7 @@ pub(crate) fn aes_cm_key_derivation(
 ) -> Result<Vec<u8>, Error> {
     if index_over_kdr != 0 {
         // 24-bit "index DIV kdr" must be xored to prf input.
-        return Err(Error::new(
-            "index_over_kdr > 0 is not supported yet".to_owned(),
-        ));
+        return Err(Error::UnsupportedIndexOverKdr);
     }
 
     // https://tools.ietf.org/html/rfc3711#appendix-B.3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 mod cipher;
 pub mod config;
 pub mod context;
-mod error;
+pub mod error;
 mod key_derivation;
 pub mod option;
 mod protection_profile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod cipher;
 pub mod config;
 pub mod context;
+mod error;
 mod key_derivation;
 pub mod option;
 mod protection_profile;

--- a/src/protection_profile/mod.rs
+++ b/src/protection_profile/mod.rs
@@ -1,6 +1,6 @@
 use super::cipher::cipher_aead_aes_gcm::*;
 use super::cipher::cipher_aes_cm_hmac_sha1::*;
-use util::Error;
+use crate::error::Error;
 mod test;
 
 /// ProtectionProfile specifies Cipher and AuthTag details, similar to TLS cipher suite

--- a/src/session/session_rtcp_test.rs
+++ b/src/session/session_rtcp_test.rs
@@ -1,14 +1,13 @@
 #[cfg(test)]
 mod session_rtcp_test {
     use crate::{
-        config, context::Context, protection_profile::ProtectionProfile, session::Session,
-        stream::Stream,
+        config, context::Context, error::Error, protection_profile::ProtectionProfile,
+        session::Session, stream::Stream,
     };
 
     use std::io::{BufReader, BufWriter};
 
     use util::conn::conn_pipe::*;
-    use util::Error;
 
     use std::sync::Arc;
     use tokio::sync::{mpsc, Mutex};

--- a/src/session/session_rtp_test.rs
+++ b/src/session/session_rtp_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod session_rtp_test {
     use crate::{
-        config, config::Config, context::Context, protection_profile::ProtectionProfile,
-        session::Session, stream::Stream,
+        config, config::Config, context::Context, error::Error,
+        protection_profile::ProtectionProfile, session::Session, stream::Stream,
     };
 
     use std::{collections::HashMap, io::BufWriter, sync::Arc};
@@ -11,8 +11,6 @@ mod session_rtp_test {
         net::UdpSocket,
         sync::{mpsc, Mutex},
     };
-
-    use util::Error;
 
     async fn build_session_srtp_pair() -> Result<(Session, Session), Error> {
         let ua = UdpSocket::bind("127.0.0.1:0").await?;


### PR DESCRIPTION
* Add dependency on thiserror

I've refactored error handling to be a crate-specific Error enum, so the error cases for this crate are explicit. 😄 I've tried to make minimal changes to the project, keeping the error messages similar. I've used dtolnay's thiserror crate to simplify the implementation, it gets compiled away so it doesn't become a part of the API of the crate or a dependency of downstream crates like failure or anyhow would.